### PR TITLE
Expires attr for tile index

### DIFF
--- a/nddynamo/boss_tileindexdb.py
+++ b/nddynamo/boss_tileindexdb.py
@@ -35,6 +35,9 @@ from random import randrange
 # Expire tile entries after this many days.
 DAYS_TO_LIVE = 21
 
+# Name of global secondary index that indexes by appended_task_id.
+TASK_INDEX = 'task_id_index'
+
 class BossTileIndexDB:
 
   def __init__(self, project_name, region_name=settings.REGION_NAME, endpoint_url=None):
@@ -312,7 +315,7 @@ class BossTileIndexDB:
             (dict): Response dictionary.
         """
         args = {
-            'IndexName': 'task_index',
+            'IndexName': TASK_INDEX,
             'KeyConditionExpression': 'appended_task_id = :task_id',
             'ExpressionAttributeValues': { ':task_id': appended_task_id },
             'Limit': limit

--- a/nddynamo/schemas/boss_tile_index.json
+++ b/nddynamo/schemas/boss_tile_index.json
@@ -25,7 +25,7 @@
   ],
   "GlobalSecondaryIndexes": [
     {
-      "IndexName": "task_index",
+      "IndexName": "task_id_index",
       "KeySchema": [
         {
           "AttributeName": "appended_task_id",

--- a/nddynamo/schemas/boss_tile_index.json
+++ b/nddynamo/schemas/boss_tile_index.json
@@ -17,6 +17,10 @@
     {
       "AttributeName": "task_id",
       "AttributeType": "N"
+    },
+    {
+      "AttributeName": "appended_task_id",
+      "AttributeType": "S"
     }
   ],
   "GlobalSecondaryIndexes": [
@@ -24,7 +28,7 @@
       "IndexName": "task_index",
       "KeySchema": [
         {
-          "AttributeName": "task_id",
+          "AttributeName": "appended_task_id",
           "KeyType": "HASH"
         }
       ],

--- a/nddynamo/schemas/boss_tile_index.json
+++ b/nddynamo/schemas/boss_tile_index.json
@@ -40,5 +40,9 @@
   "ProvisionedThroughput": {
     "ReadCapacityUnits": 10,
     "WriteCapacityUnits": 10
+  },
+  "TimeToLiveSpecification": {
+    "AttributeName": "expires",
+    "Enabled": true
   }
 }

--- a/settings/boss_build_settings.py
+++ b/settings/boss_build_settings.py
@@ -46,6 +46,7 @@ def create_settings(tmpl_fp, boss_fp):
     nd_config['aws']['cuboid_bucket'] = boss_config['aws']['cuboid_bucket']
     nd_config['aws']['tile_index_table'] = boss_config['aws']['tile-index-table']
     nd_config['aws']['cuboid_index_table'] = boss_config['aws']['s3-index-table']
+    nd_config['aws']['max_task_id_suffix'] = 100
 
     nd_config['spdb']['SUPER_CUBOID_SIZE'] = ', '.join(str(x) for x in CUBOIDSIZE[0])
 

--- a/settings/bosssettings.py
+++ b/settings/bosssettings.py
@@ -69,13 +69,13 @@ class BossSettings(Settings):
     @property
     def S3_CUBOID_BUCKET(self):
         if self._test_mode:
-            return 'test_{}'.format(self.parser.get('aws', 'cuboid_bucket'))
+            return 'test-{}'.format(self.parser.get('aws', 'cuboid_bucket'))
         return self.parser.get('aws', 'cuboid_bucket')
 
     @property
     def S3_TILE_BUCKET(self):
         if self._test_mode:
-            return 'test_{}'.format(self.parser.get('aws', 'tile_bucket'))
+            return 'test-{}'.format(self.parser.get('aws', 'tile_bucket'))
         return self.parser.get('aws', 'tile_bucket')
 
     @property

--- a/settings/bosssettings.py
+++ b/settings/bosssettings.py
@@ -91,6 +91,10 @@ class BossSettings(Settings):
         return self.parser.get('aws', 'tile_index_table')
 
     @property
+    def MAX_TASK_ID_SUFFIX(self):
+        return int(self.parser.get('aws', 'max_task_id_suffix'))
+
+    @property
     def UPLOAD_TASK_QUEUE(self):
         return self.parser.get('aws', 'upload_task_queue_url')
 

--- a/settings/settings.ini.apl
+++ b/settings/settings.ini.apl
@@ -9,6 +9,7 @@ tile_bucket =
 cuboid_bucket =
 tile_index_table =
 cuboid_index_table =
+max_task_id_suffix =
 [spdb]
 SUPER_CUBOID_SIZE =
 [testing]

--- a/test/test_bosstileindexdb.py
+++ b/test/test_bosstileindexdb.py
@@ -98,9 +98,10 @@ class Test_BossTileIndexDB(unittest.TestCase):
         chunk_key = '<hash>&{}&111&222&333&0&0&0&0&0'.format(num_tiles)
         task_id = 21
         self.tileindex_db.createCuboidEntry(chunk_key, task_id)
-        preDelResp = self.tileindex_db.getCuboid(chunk_key, task_id)
-        self.assertEqual(chunk_key, preDelResp['chunk_key'])
-        self.assertEqual({}, preDelResp['tile_uploaded_map'])
+        actual = self.tileindex_db.getCuboid(chunk_key, task_id)
+        self.assertEqual(chunk_key, actual['chunk_key'])
+        self.assertEqual({}, actual['tile_uploaded_map'])
+        self.assertIn('expires', actual)
 
 
     def test_markTileAsUploaded(self):
@@ -172,8 +173,14 @@ class Test_BossTileIndexDB(unittest.TestCase):
         ]
 
         actual = list(self.tileindex_db.getTaskItems(3))
+        filtered = [
+            {
+                'task_id': i['task_id'],
+                'tile_uploaded_map': i['tile_uploaded_map'],
+                'chunk_key': i['chunk_key']
+            } for i in actual]
 
-        six.assertCountEqual(self, expected, actual)
+        six.assertCountEqual(self, expected, filtered)
 
 
     def test_createCuboidAlreadyExistsRaises(self):


### PR DESCRIPTION
Add time-to-live attribute to the tile index as a fallback in case ingest cleanup fails.

Entries in the tile index will be deleted if they're over 21 days old.

Linked PR: https://github.com/jhuapl-boss/boss-manage/pull/12