### PR TITLE
Added task index GSI back to tile index table.

### DIFF
--- a/nddynamo/boss_tileindexdb.py
+++ b/nddynamo/boss_tileindexdb.py
@@ -35,6 +35,9 @@ from random import randrange
 # Expire tile entries after this many days.
 DAYS_TO_LIVE = 21
 
+# Name of global secondary index that indexes by appended_task_id.
+TASK_INDEX = 'task_id_index'
+
 class BossTileIndexDB:
 
   def __init__(self, project_name, region_name=settings.REGION_NAME, endpoint_url=None):
@@ -312,7 +315,7 @@ class BossTileIndexDB:
             (dict): Response dictionary.
         """
         args = {
-            'IndexName': 'task_index',
+            'IndexName': TASK_INDEX,
             'KeyConditionExpression': 'appended_task_id = :task_id',
             'ExpressionAttributeValues': { ':task_id': appended_task_id },
             'Limit': limit

--- a/nddynamo/schemas/boss_tile_index.json
+++ b/nddynamo/schemas/boss_tile_index.json
@@ -25,7 +25,7 @@
   ],
   "GlobalSecondaryIndexes": [
     {
-      "IndexName": "task_index",
+      "IndexName": "task_id_index",
       "KeySchema": [
         {
           "AttributeName": "appended_task_id",

--- a/nddynamo/schemas/boss_tile_index.json
+++ b/nddynamo/schemas/boss_tile_index.json
@@ -17,6 +17,10 @@
     {
       "AttributeName": "task_id",
       "AttributeType": "N"
+    },
+    {
+      "AttributeName": "appended_task_id",
+      "AttributeType": "S"
     }
   ],
   "GlobalSecondaryIndexes": [
@@ -24,7 +28,7 @@
       "IndexName": "task_index",
       "KeySchema": [
         {
-          "AttributeName": "task_id",
+          "AttributeName": "appended_task_id",
           "KeyType": "HASH"
         }
       ],

--- a/settings/boss_build_settings.py
+++ b/settings/boss_build_settings.py
@@ -46,6 +46,7 @@ def create_settings(tmpl_fp, boss_fp):
     nd_config['aws']['cuboid_bucket'] = boss_config['aws']['cuboid_bucket']
     nd_config['aws']['tile_index_table'] = boss_config['aws']['tile-index-table']
     nd_config['aws']['cuboid_index_table'] = boss_config['aws']['s3-index-table']
+    nd_config['aws']['max_task_id_suffix'] = 100
 
     nd_config['spdb']['SUPER_CUBOID_SIZE'] = ', '.join(str(x) for x in CUBOIDSIZE[0])
 

--- a/settings/bosssettings.py
+++ b/settings/bosssettings.py
@@ -91,6 +91,10 @@ class BossSettings(Settings):
         return self.parser.get('aws', 'tile_index_table')
 
     @property
+    def MAX_TASK_ID_SUFFIX(self):
+        return int(self.parser.get('aws', 'max_task_id_suffix'))
+
+    @property
     def UPLOAD_TASK_QUEUE(self):
         return self.parser.get('aws', 'upload_task_queue_url')
 

--- a/settings/settings.ini.apl
+++ b/settings/settings.ini.apl
@@ -9,6 +9,7 @@ tile_bucket =
 cuboid_bucket =
 tile_index_table =
 cuboid_index_table =
+max_task_id_suffix =
 [spdb]
 SUPER_CUBOID_SIZE =
 [testing]


### PR DESCRIPTION
Renamed index to `task_id_index` because CloudFormation update does not allow changing the index's key schema.

Now using appended_task_id as the attribute to index on.  This holds the ingest job id with an underscore and random number appended to it
(up to MAX_TILE_ID_SUFFIX) so that writes are spread across partitions.

Related PR: https://github.com/jhuapl-boss/boss-manage/pull/13