### PR TITLE
Refactor region

### DIFF
--- a/settings/boss_build_settings.py
+++ b/settings/boss_build_settings.py
@@ -42,6 +42,7 @@ def create_settings(tmpl_fp, boss_fp):
 
     nd_config['boss']['domain'] = boss_config['system']['fqdn'].split('.', 1)[1]
 
+    nd_config['aws']['region'] = 'us-east-1' # Hardcoded for testing
     nd_config['aws']['tile_bucket'] = boss_config['aws']['tile_bucket']
     nd_config['aws']['cuboid_bucket'] = boss_config['aws']['cuboid_bucket']
     nd_config['aws']['tile_index_table'] = boss_config['aws']['tile-index-table']

--- a/settings/settings.ini.apl
+++ b/settings/settings.ini.apl
@@ -4,7 +4,7 @@ DEV_MODE = False
 [boss]
 domain =
 [aws]
-region = us-east-1
+region =
 tile_bucket =
 cuboid_bucket =
 tile_index_table =


### PR DESCRIPTION
Made the AWS region a required parameter in the default APL config, so that we don't accidentally forget to set the region.