### PR TITLE
Run CI using CircleCI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,0 +1,41 @@
+version: 2.1
+orbs:
+  python: circleci/python@0.2.1
+
+commands:
+  install:
+    description: "Install Python dependencies"
+    steps:
+      - checkout
+      - python/load-cache
+      - python/install-deps
+      - python/save-cache
+
+  test_ndingest:
+    description: "Test ndingest"
+    steps:
+      - run: ln -s /home/circleci/project /home/circleci/ndingest
+      - run: cp settings/settings.ini.test settings/settings.ini
+      - run: python -m pytest -c test_apl.cfg
+jobs:
+  test_py3_5:
+    docker:
+      - image: circleci/python:3.5
+      - image: circleci/dynamodb:latest
+    environment:
+      NDINGEST_TEST: 1
+      AWS_ACCESS_KEY_ID: testing
+      AWS_SECRET_ACCESS_KEY: testing
+      AWS_SECURITY_TOKEN: testing
+      AWS_SESSION_TOKEN: testing
+      PYTHONPATH: /home/circleci/
+    steps:
+      - install
+      - test_ndingest
+
+workflows:
+  version: 2
+  test:
+    jobs:
+      - test_py3_5
+

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,3 @@
+boto3
+moto
+pytest

--- a/settings/settings.ini.test
+++ b/settings/settings.ini.test
@@ -1,0 +1,21 @@
+[proj]
+project_name = Boss
+dev_mode = False
+
+[boss]
+domain = bosstest.boss
+
+[aws]
+region = us-east-1
+tile_bucket = testtiles.bosstest.boss
+cuboid_bucket = testcuboids.bosstest.boss
+tile_index_table = tileindex.bosstest.boss
+cuboid_index_table = s3index.bosstest.boss
+max_task_id_suffix = 100
+
+[spdb]
+super_cuboid_size = 512, 512, 16
+
+[testing]
+dynamo_endpoint = http://localhost:8000
+

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -1,0 +1,67 @@
+# Copyright 2014 NeuroData (http://neurodata.io)
+# Copyright 2020 The Johns Hopkins University Applied Physics Laboratory
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""
+This file contains pytest fixtures that will automatically be discovered and
+injected into test functions by pytest.
+"""
+
+import boto3
+from moto import mock_s3, mock_iam, mock_sqs
+import os
+import pytest
+
+from ndingest.settings.settings import Settings
+settings = Settings.load()
+from io import BytesIO
+from ndingest.ndingestproj.ingestproj import IngestProj
+
+ProjClass = IngestProj.load()
+if settings.PROJECT_NAME == 'Boss':
+    nd_proj = ProjClass('testCol', 'kasthuri11', 'image', 0, 124)
+else:
+    nd_proj = ProjClass('kasthuri11', 'image', '0')
+
+
+@pytest.fixture(scope='function')
+def aws_credentials():
+    """Mocked AWS Credentials for moto."""
+    os.environ['AWS_ACCESS_KEY_ID'] = 'testing'
+    os.environ['AWS_SECRET_ACCESS_KEY'] = 'testing'
+    os.environ['AWS_SECURITY_TOKEN'] = 'testing'
+    os.environ['AWS_SESSION_TOKEN'] = 'testing'
+
+@pytest.fixture(scope='function')
+def s3(aws_credentials):
+    with mock_s3():
+        yield boto3.client('s3', region_name='us-east-1')
+
+@pytest.fixture(scope='function')
+def iam(aws_credentials):
+    with mock_iam():
+        yield boto3.client('iam', region_name='us-east-1')
+
+@pytest.fixture(scope='function')
+def sqs(aws_credentials):
+    with mock_sqs():
+        #yield boto3.client('sqs', region_name='us-east-1')
+        yield boto3.resource('sqs', region_name='us-east-1')
+
+@pytest.fixture(scope='function')
+def tile_bucket(s3, iam):
+    from ndingest.ndbucket.tilebucket import TileBucket
+    TileBucket.createBucket()
+    yield TileBucket(nd_proj.project_name)
+    TileBucket.deleteBucket()

--- a/test/test_deadletter_queue.py
+++ b/test/test_deadletter_queue.py
@@ -1,5 +1,5 @@
 # Copyright 2014 NeuroData (http://neurodata.io)
-# Copyright 2016 The Johns Hopkins University Applied Physics Laboratory
+# Copyright 2020 The Johns Hopkins University Applied Physics Laboratory
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -13,157 +13,126 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from __future__ import absolute_import
-from __future__ import print_function
-import sys
-sys.path.append('..')
+import botocore
+import json
+from random import randint
+import pytest
 from ndingest.settings.settings import Settings
 settings = Settings.load()
-import json
-from ndingest.ndqueue.ndqueue import NDQueue
-from ndingest.ndqueue.uploadqueue import UploadQueue
-from ndingest.ndqueue.serializer import Serializer
-serializer = Serializer.load()
 from ndingest.ndingestproj.ingestproj import IngestProj
 ProjClass = IngestProj.load()
-from random import randint
-import unittest
-import boto3
-import botocore
-import time
-import warnings
 
-class TestDeadletterQueue(unittest.TestCase):
-    def setUp(self):
-        # Suppress ResourceWarning messages about unclosed connections.
-        warnings.simplefilter('ignore')
+def generate_proj():
+    """Add some randomness to the project.
+   
+    Queue names must be different between tests because a deleted queue
+    cannot be recreated with the same name until 60s has elapsed.
+    """
 
-        if 'SQS_ENDPOINT' in dir(settings):
-          self.endpoint_url = settings.SQS_ENDPOINT
-        else:
-          self.endpoint_url = None
+    num = 100
 
-        self.upload_queue = None
-        self.nd_proj = self.generate_proj()
+    if settings.PROJECT_NAME == 'Boss':
+        job_id = num
+        nd_proj = ProjClass('testCol', 'kasthuri11', 'image', 0, job_id)
+    else:
+        channel = 'image{}'.format(num)
+        nd_proj = ProjClass('kasthuri11', channel, '0')
 
-    def tearDown(self):
-        if self.upload_queue is not None:
-            self.upload_queue.queue.delete()
+    return nd_proj
 
-    def generate_proj(self):
-        """Add some randomness to the project.
-       
-        Queue names must be different between tests because a deleted queue
-        cannot be recreated with the same name until 60s has elapsed.
-        """
+def test_create_queue_with_default_name(sqs):
+    from ndingest.ndqueue.uploadqueue import UploadQueue
 
-        num = randint(100, 999)
+    proj = generate_proj()
 
-        if settings.PROJECT_NAME == 'Boss':
-            job_id = num
-            nd_proj = ProjClass('testCol', 'kasthuri11', 'image', 0, job_id)
-        else:
-            channel = 'image{}'.format(num)
-            nd_proj = ProjClass('kasthuri11', channel, '0')
+    # Create upload queue.
+    UploadQueue.createQueue(proj)
+    upload_queue = UploadQueue(proj)
 
-        return nd_proj
+    # Create dead letter queue with default name.
+    exp_max_receives = 4
+    dl_queue = upload_queue.addDeadLetterQueue(exp_max_receives)
 
-    def test_create_queue_with_default_name(self):
+    exp_name = upload_queue.queue_name + '-dlq'
+    exp_arn = dl_queue.attributes['QueueArn']
+
+    try:
+        policy = json.loads(
+            upload_queue.queue.attributes['RedrivePolicy'])
+        assert exp_max_receives == policy['maxReceiveCount']
+        assert exp_arn == policy['deadLetterTargetArn']
+        # Confirm dead letter queue named correctly by looking at the end 
+        # of its ARN.
+        assert dl_queue.attributes['QueueArn'].endswith(exp_name)
+    finally:
+        dl_queue.delete()
+
+def test_add_existing_queue_as_dead_letter_queue(sqs):
+    from ndingest.ndqueue.uploadqueue import UploadQueue
+
+    proj = generate_proj()
+
+    # Create existing queue for dead letter queue.
+    queue_name = 'deadletter_test_{}'.format(randint(1000, 9999))
+    existing_queue = sqs.create_queue(
+        QueueName=queue_name,
+        Attributes={
+            'DelaySeconds': '0',
+            'MaximumMessageSize': '262144'
+        }
+    )
+
+    exp_arn = existing_queue.attributes['QueueArn']
+
+    try:
         # Create upload queue.
-        UploadQueue.createQueue(self.nd_proj, endpoint_url=self.endpoint_url)
-        self.upload_queue = UploadQueue(self.nd_proj, endpoint_url=self.endpoint_url)
-
-        # Create dead letter queue with default name.
-        exp_max_receives = 4
-        dl_queue = self.upload_queue.addDeadLetterQueue(exp_max_receives)
-
-        exp_name = self.upload_queue.queue_name + '-dlq'
-        exp_arn = dl_queue.attributes['QueueArn']
-
-        try:
-            policy = json.loads(
-                self.upload_queue.queue.attributes['RedrivePolicy'])
-            self.assertEqual(exp_max_receives, policy['maxReceiveCount'])
-            self.assertEqual(exp_arn, policy['deadLetterTargetArn'])
-            # Confirm dead letter queue named correctly by looking at the end 
-            # of its ARN.
-            self.assertTrue(dl_queue.attributes['QueueArn'].endswith(exp_name))
-        finally:
-            dl_queue.delete()
-
-
-    def test_add_existing_queue_as_dead_letter_queue(self):
-        # Create existing queue for dead letter queue.
-        sqs = boto3.resource(
-            'sqs',
-            region_name=settings.REGION_NAME, endpoint_url=self.endpoint_url, 
-            aws_access_key_id=settings.AWS_ACCESS_KEY_ID, 
-            aws_secret_access_key=settings.AWS_SECRET_ACCESS_KEY)
-        queue_name = 'deadletter_test_{}'.format(randint(100, 999))
-        existing_queue = sqs.create_queue(
-            QueueName=queue_name,
-            Attributes={
-                'DelaySeconds': '0',
-                'MaximumMessageSize': '262144'
-            }
-        )
-
-        exp_arn = existing_queue.attributes['QueueArn']
-
-        try:
-            # Create upload queue.
-            UploadQueue.createQueue(self.nd_proj, endpoint_url=self.endpoint_url)
-            self.upload_queue = UploadQueue(self.nd_proj, endpoint_url=self.endpoint_url)
-
-            # Attach the dead letter queue to it.
-            exp_max_receives = 5
-            dl_queue = self.upload_queue.addDeadLetterQueue(
-                exp_max_receives, exp_arn)
-
-            # Confirm policy settings.
-            policy = json.loads(
-                self.upload_queue.queue.attributes['RedrivePolicy'])
-            self.assertEqual(exp_max_receives, policy['maxReceiveCount'])
-            self.assertEqual(exp_arn, policy['deadLetterTargetArn'])
-
-            # Confirm dead letter queue is the one created at the beginning 
-            # of test.
-            self.assertEqual(existing_queue.url, dl_queue.url)
-        finally:
-            existing_queue.delete()
-
-
-    def test_delete_dead_letter_queue(self):
-        # Create existing queue for dead letter queue.
-        sqs = boto3.resource(
-            'sqs',
-            region_name=settings.REGION_NAME, endpoint_url=self.endpoint_url, 
-            aws_access_key_id=settings.AWS_ACCESS_KEY_ID, 
-            aws_secret_access_key=settings.AWS_SECRET_ACCESS_KEY)
-        queue_name = 'deadletter_test_{}'.format(randint(100, 999))
-        existing_queue = sqs.create_queue(
-            QueueName=queue_name,
-            Attributes={
-                'DelaySeconds': '0',
-                'MaximumMessageSize': '262144'
-            }
-        )
-
-        # Create upload queue. 
-        arn = existing_queue.attributes['QueueArn']
-        UploadQueue.createQueue(self.nd_proj, endpoint_url=self.endpoint_url)
-        self.upload_queue = UploadQueue(self.nd_proj, endpoint_url=self.endpoint_url)
+        UploadQueue.createQueue(proj)
+        upload_queue = UploadQueue(proj)
 
         # Attach the dead letter queue to it.
-        dl_queue = self.upload_queue.addDeadLetterQueue(2, arn)
+        exp_max_receives = 5
+        dl_queue = upload_queue.addDeadLetterQueue(
+            exp_max_receives, exp_arn)
 
-        # Invoke the delete method.
-        NDQueue.deleteDeadLetterQueue(sqs, self.upload_queue.queue)
+        # Confirm policy settings.
+        policy = json.loads(
+            upload_queue.queue.attributes['RedrivePolicy'])
+        assert exp_max_receives == policy['maxReceiveCount']
+        assert exp_arn == policy['deadLetterTargetArn']
 
-        # Confirm deletion.
-        with self.assertRaises(botocore.exceptions.ClientError):
-            sqs.get_queue_by_name(QueueName=queue_name)
+        # Confirm dead letter queue is the one created at the beginning 
+        # of test.
+        assert existing_queue.url == dl_queue.url
+    finally:
+        existing_queue.delete()
 
+def test_delete_dead_letter_queue(sqs):
+    from ndingest.ndqueue.uploadqueue import NDQueue
+    from ndingest.ndqueue.uploadqueue import UploadQueue
 
-if __name__ == '__main__':
-    unittest.main()
+    proj = generate_proj()
+
+    # Create existing queue for dead letter queue.
+    queue_name = 'deadletter_test_{}'.format(randint(1000, 9999))
+    existing_queue = sqs.create_queue(
+        QueueName=queue_name,
+        Attributes={
+            'DelaySeconds': '0',
+            'MaximumMessageSize': '262144'
+        }
+    )
+
+    # Create upload queue. 
+    arn = existing_queue.attributes['QueueArn']
+    UploadQueue.createQueue(proj)
+    upload_queue = UploadQueue(proj)
+
+    # Attach the dead letter queue to it.
+    dl_queue = upload_queue.addDeadLetterQueue(2, arn)
+
+    # Invoke the delete method.
+    NDQueue.deleteDeadLetterQueue(sqs, upload_queue.queue)
+
+    # Confirm deletion.
+    with pytest.raises(botocore.exceptions.ClientError):
+        sqs.get_queue_by_name(QueueName=queue_name)


### PR DESCRIPTION
Convert tests to unit tests.  Previously, tests worked with real AWS
resources.  Use moto and pytest fixtures instead.  Don't want to touch
real AWS resources when run in CI.

Tried using CIRCLE_CI_WORKING_DIR env var for paths, but the Docker
image's OS did not seem to like the `~` in the variable when running
commands.  Switched to using hard coded path to the project folder.